### PR TITLE
removed dialog prompt

### DIFF
--- a/src/lib/build.ts
+++ b/src/lib/build.ts
@@ -248,20 +248,7 @@ export class Build {
         const setting = SplConfig.getSetting(Config.TOOLKITS_PATH);
         if (setting.trim() !== '') {
             return setting;
-        } else {
-            return window.showOpenDialog({
-                'canSelectFiles': false,
-                'canSelectFolders': true,
-                'canSelectMany': false,
-                'openLabel': 'Set as IBM Streams toolkits directory'
-            }).then((selected: Uri[]) => {
-                let dir = null;
-                if (selected && selected.length === 1) {
-                    dir = selected[0].fsPath;
-                    SplConfig.setSetting(Config.TOOLKITS_PATH, dir);
-                }
-                return dir;
-            });
-        }
+        } 
+        return null;
     }
 }


### PR DESCRIPTION
Removed the dialog prompt for toolkitpath since these are optional and it is confusing to have it constantly showing when tyring to build something.